### PR TITLE
I've tried this with a long set and it broke, so I'm proposing a fix

### DIFF
--- a/lib/holt-winters-memoize.js
+++ b/lib/holt-winters-memoize.js
@@ -20,7 +20,7 @@ function memoize(opt) {
 		gamma = opt.gamma,
 		period = opt.period,
 		m = opt.m,
-		seasons = len / period,
+		seasons = Math.floor(len / period),
 
 		// reuse these
 		// note: savg[] and si[] zero-filled on every run

--- a/lib/holt-winters.js
+++ b/lib/holt-winters.js
@@ -16,7 +16,7 @@ function forecast(data, alpha, beta, gamma, period, m) {
 	if (!validArgs(data, alpha, beta, gamma, period, m))
 		return;
 
-	seasons = data.length / period;
+	seasons = Math.floor(data.length / period);
 	st_1 = data[0];
 	bt_1 = initialTrend(data, period);
 	seasonal = seasonalIndices(data, period, seasons);


### PR DESCRIPTION
If you'd like to try this

```
var forecast = require("nostradamus")
var data =[ 44,46,49,51,46,53,48,42,46,42,43,43,38,38,36,35,36,37,36,36,33,33,36,30,30,33,32,35,33,32,35,33,35,100,62,41,42,46,48,47,45,43,42,42,40,42,45,42,40,47,41,51,45,46,47,48,48,51,53,52,47,51,52,44,43,41,41,40,42,43,39,41,41,44,37,37,39,40,42,42,42,39,40,39,38,42,37,42,43,49,50,50,45,53,46,49,45,47,47,51,48,50,53,51,59,53,63,66,61,60,63,62,67,57,57,56,55,51,47,48,47,46,42,44,45,45,44,45,47,46,46,39,44,47,42,43,44,42,44,45,49,53,52,59,57,56,51,53,52,52,50,55,52,56,57,62,63];
var alpha = 0.5  // overall smoothing component
var beta = 0.4   // trend smoothing component
var gamma = 0.6  // seasonal smoothing component
var period = 5   // # of observations per season
var m = 4        // # of future observations to forecast
var predictions = [];

predictions = forecast(data, alpha, beta, gamma, period, m);
```